### PR TITLE
Remove manually creating tables

### DIFF
--- a/scaffold-api/src/scaffold_api/__init__.py
+++ b/scaffold-api/src/scaffold_api/__init__.py
@@ -63,8 +63,6 @@ def create_app(run_mode=os.getenv("FLASK_ENV", "development")):
 
     # # Database migrate initialize
     migrate.init_app(app, db)
-    with app.app_context():
-        db.create_all()
 
     # Marshmallow initialize
     ma.init_app(app)


### PR DESCRIPTION
revert change to manually create tables. It should be managed by alembic

This caused a side effect that if tables are added or deleted, on running flask db migrate no migration scripts are added with the logic to create those tables